### PR TITLE
Add FastAPI API for units and categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# WCR Data API
+
+This project provides a simple REST API to serve data from `data/units.json` and `data/categories.json`.
+
+## Requirements
+
+- Python 3.11
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the API
+
+Run the application with `uvicorn`:
+
+```bash
+uvicorn main:app --reload
+```
+
+The API will expose the following endpoints:
+
+- `GET /units` – list all units
+- `GET /units/{id}` – get a unit by ID
+- `GET /categories` – list categories (factions, types, traits, speeds)

--- a/app/api.py
+++ b/app/api.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, HTTPException
+
+from .loaders import get_data_loader
+
+router = APIRouter()
+
+
+@router.get("/units")
+def list_units():
+    """Return all units."""
+    loader = get_data_loader()
+    return loader.units
+
+
+@router.get("/units/{unit_id}")
+def get_unit(unit_id: str):
+    """Return unit details by ID."""
+    loader = get_data_loader()
+    for unit in loader.units:
+        if unit.get("id") == unit_id:
+            return unit
+    raise HTTPException(status_code=404, detail="Unit not found")
+
+
+@router.get("/categories")
+def list_categories():
+    """Return categories data."""
+    loader = get_data_loader()
+    return loader.categories

--- a/app/loaders.py
+++ b/app/loaders.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+class DataLoader:
+    """Loads data from JSON files and keeps them in memory."""
+
+    def __init__(self, data_dir: Path) -> None:
+        self.data_dir = data_dir
+        self.units: List[Dict[str, Any]] = []
+        self.categories: Dict[str, Any] = {}
+
+    def load(self) -> None:
+        """Load units and categories from JSON files."""
+        units_file = self.data_dir / "units.json"
+        categories_file = self.data_dir / "categories.json"
+        with units_file.open("r", encoding="utf-8") as f:
+            self.units = json.load(f)
+        with categories_file.open("r", encoding="utf-8") as f:
+            self.categories = json.load(f)
+
+
+data_loader: DataLoader | None = None
+
+
+def get_data_loader() -> DataLoader:
+    """Return a singleton DataLoader instance."""
+    global data_loader
+    if data_loader is None:
+        data_loader = DataLoader(Path(__file__).resolve().parent.parent / "data")
+        data_loader.load()
+    return data_loader

--- a/main.py
+++ b/main.py
@@ -1,0 +1,14 @@
+from fastapi import FastAPI
+
+from app.api import router
+
+app = FastAPI(title="WCR Data API")
+app.include_router(router)
+
+
+@app.on_event("startup")
+def startup_event():
+    # Load data at startup
+    from app.loaders import get_data_loader
+
+    get_data_loader()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.0.post1


### PR DESCRIPTION
## Summary
- serve units and categories data via FastAPI
- load JSON data on startup and keep in memory
- add simple README with usage instructions
- add dependencies for FastAPI and Uvicorn

## Testing
- `pip install -r requirements.txt`
- `uvicorn main:app --port 8000 --reload` *(logs inspected)*

------
https://chatgpt.com/codex/tasks/task_e_6859d6e26c7c832fb261650c4e03f3f6