### PR TITLE
Update README with API usage details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,72 @@
 # WCR Data API
 
-This project provides a simple REST API to serve data from `data/units.json` and `data/categories.json`.
+This project provides a simple REST API to serve data from `data/units.json` and
+`data/categories.json`.
 
 ## Requirements
 
 - Python 3.11
 
-Install dependencies:
+## Local Development
+
+Install dependencies and start the application with `uvicorn`:
 
 ```bash
 pip install -r requirements.txt
-```
-
-## Running the API
-
-Run the application with `uvicorn`:
-
-```bash
 uvicorn main:app --reload
 ```
 
-The API will expose the following endpoints:
+When running locally the API is available at `http://127.0.0.1:8000`.
+
+## Hosted API
+
+The API is also deployed and accessible under:
+
+```
+https://wcr-api.up.railway.app
+```
+
+### Available Endpoints
 
 - `GET /units` – list all units
 - `GET /units/{id}` – get a unit by ID
 - `GET /categories` – list categories (factions, types, traits, speeds)
+
+All endpoints return JSON.
+
+### Examples
+
+Fetch all units:
+
+```bash
+curl https://wcr-api.up.railway.app/units
+```
+
+Fetch a single unit:
+
+```bash
+curl https://wcr-api.up.railway.app/units/abomination
+```
+
+Fetch categories:
+
+```bash
+curl https://wcr-api.up.railway.app/categories
+```
+
+#### Example usage in Python
+
+```python
+import requests
+
+base_url = "https://wcr-api.up.railway.app"
+
+# list units
+units = requests.get(f"{base_url}/units").json()
+
+# single unit by id
+unit = requests.get(f"{base_url}/units/abomination").json()
+
+# categories
+categories = requests.get(f"{base_url}/categories").json()
+```


### PR DESCRIPTION
## Summary
- document how to use the hosted API at wcr-api.up.railway.app
- provide examples for cURL and Python usage
- clarify local development instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859eddbee3c832fb6d6be35329286cd