### PR TITLE
Improve loader lookups and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ uvicorn main:app --reload
 
 When running locally the API is available at `http://127.0.0.1:8000`.
 
+### Data loading
+
+Unit data is loaded once at startup by `DataLoader` which keeps a dictionary
+for fast lookups. Use `get_unit_by_id` to retrieve a specific unit without
+iterating over the entire list.
+
 ## Hosted API
 
 The API is also deployed and accessible under:

--- a/app/api.py
+++ b/app/api.py
@@ -16,9 +16,9 @@ def list_units():
 def get_unit(unit_id: str):
     """Return unit details by ID."""
     loader = get_data_loader()
-    for unit in loader.units:
-        if unit.get("id") == unit_id:
-            return unit
+    unit = loader.get_unit_by_id(unit_id)
+    if unit:
+        return unit
     raise HTTPException(status_code=404, detail="Unit not found")
 
 

--- a/app/loaders.py
+++ b/app/loaders.py
@@ -1,24 +1,42 @@
 import json
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
+
+
+class DataLoadError(Exception):
+    """Raised when data files fail to load."""
 
 
 class DataLoader:
-    """Loads data from JSON files and keeps them in memory."""
+    """Loads data from JSON files and stores them for quick access.
+
+    Units are indexed by ID to provide constant-time lookups via
+    :meth:`get_unit_by_id`.
+    """
 
     def __init__(self, data_dir: Path) -> None:
         self.data_dir = data_dir
         self.units: List[Dict[str, Any]] = []
+        self.units_by_id: Dict[str, Dict[str, Any]] = {}
         self.categories: Dict[str, Any] = {}
 
     def load(self) -> None:
         """Load units and categories from JSON files."""
         units_file = self.data_dir / "units.json"
         categories_file = self.data_dir / "categories.json"
-        with units_file.open("r", encoding="utf-8") as f:
-            self.units = json.load(f)
-        with categories_file.open("r", encoding="utf-8") as f:
-            self.categories = json.load(f)
+        try:
+            with units_file.open("r", encoding="utf-8") as f:
+                self.units = json.load(f)
+            with categories_file.open("r", encoding="utf-8") as f:
+                self.categories = json.load(f)
+        except OSError as exc:  # file read errors
+            raise DataLoadError(str(exc)) from exc
+
+        self.units_by_id = {unit["id"]: unit for unit in self.units}
+
+    def get_unit_by_id(self, unit_id: str) -> Optional[Dict[str, Any]]:
+        """Return a unit by its ID using an efficient dictionary lookup."""
+        return self.units_by_id.get(unit_id)
 
 
 data_loader: DataLoader | None = None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,20 @@
+from fastapi.testclient import TestClient
+
+from app.loaders import get_data_loader
+from main import app
+
+
+def test_get_unit(monkeypatch):
+    client = TestClient(app)
+
+    loader = get_data_loader()
+    unit_id = loader.units[0]["id"]
+    response = client.get(f"/units/{unit_id}")
+    assert response.status_code == 200
+    assert response.json()["id"] == unit_id
+
+
+def test_unit_not_found():
+    client = TestClient(app)
+    response = client.get("/units/nonexistent")
+    assert response.status_code == 404

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,27 @@
+import json
+
+import pytest
+
+from app.loaders import DataLoader, DataLoadError
+
+
+def test_load_success(tmp_path):
+    # copy data files to temporary directory
+    data_dir = tmp_path
+    units_data = [{"id": "a", "value": 1}]
+    categories_data = {"cats": []}
+    (data_dir / "units.json").write_text(json.dumps(units_data))
+    (data_dir / "categories.json").write_text(json.dumps(categories_data))
+
+    loader = DataLoader(data_dir)
+    loader.load()
+
+    assert loader.units == units_data
+    assert loader.categories == categories_data
+    assert loader.get_unit_by_id("a") == units_data[0]
+
+
+def test_load_missing_file(tmp_path):
+    loader = DataLoader(tmp_path)
+    with pytest.raises(DataLoadError):
+        loader.load()


### PR DESCRIPTION
## Summary
- add `DataLoadError` and units-by-ID mapping
- fetch units by ID directly in API
- document dictionary lookups in README
- add tests for loader and API endpoints

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a7c6eced4832f84be423a98a632f6