### PR TITLE
Add API tests and dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ uvicorn main:app --reload
 
 When running locally the API is available at `http://127.0.0.1:8000`.
 
+### Running Tests
+
+Install development dependencies and run the test suite with `pytest`:
+
+```bash
+pip install -r requirements-dev.txt
+pytest
+```
+
 ### Data loading
 
 Unit data is loaded once at startup by `DataLoader` which keeps a dictionary

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+httpx<0.27

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,20 +1,40 @@
 from fastapi.testclient import TestClient
+import sys
+from pathlib import Path
 
-from app.loaders import get_data_loader
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from main import app
+from app.loaders import get_data_loader
+
+client = TestClient(app)
 
 
-def test_get_unit(monkeypatch):
-    client = TestClient(app)
+def test_units_list_contains_known_id():
+    loader = get_data_loader()
+    known_id = loader.units[0]["id"]
+    response = client.get("/units")
+    assert response.status_code == 200
+    units = response.json()
+    assert isinstance(units, list)
+    assert any(u["id"] == known_id for u in units)
 
+
+def test_get_unit_by_id_or_404():
     loader = get_data_loader()
     unit_id = loader.units[0]["id"]
-    response = client.get(f"/units/{unit_id}")
+
+    resp_ok = client.get(f"/units/{unit_id}")
+    assert resp_ok.status_code == 200
+    assert resp_ok.json()["id"] == unit_id
+
+    resp_404 = client.get("/units/nonexistent")
+    assert resp_404.status_code == 404
+
+
+def test_categories_structure():
+    response = client.get("/categories")
     assert response.status_code == 200
-    assert response.json()["id"] == unit_id
-
-
-def test_unit_not_found():
-    client = TestClient(app)
-    response = client.get("/units/nonexistent")
-    assert response.status_code == 404
+    categories = response.json()
+    assert isinstance(categories, dict)
+    assert {"factions", "types", "traits", "speeds"} <= set(categories.keys())

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,6 +1,10 @@
 import json
+import sys
+from pathlib import Path
 
 import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from app.loaders import DataLoader, DataLoadError
 


### PR DESCRIPTION
## Summary
- add dev requirements for pytest and httpx
- extend `tests/test_api.py` with endpoint tests
- update loader tests for package import
- document how to run tests in README

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt --force-reinstall`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a7e160d20832f94ecc335d049c650