### PR TITLE
Improve docs and add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+### Added
+- Expanded docstrings for `DataLoader` and API endpoints.
+- Initial changelog tracking features and dependency updates.
+
+## [0.1.0] - 2025-06-24
+### Added
+- FastAPI API serving units and categories.
+- `DataLoader` for cached lookups.
+- Pre-commit hooks and CI workflow.
+### Changed
+- Updated dependencies: FastAPI, Uvicorn and httpx.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 This project provides a simple REST API to serve data from `data/units.json` and
 `data/categories.json`.
 
+See [CHANGELOG.md](CHANGELOG.md) for release notes.
+
 ## Requirements
 
 - Python 3.11

--- a/app/api.py
+++ b/app/api.py
@@ -6,19 +6,36 @@ router = APIRouter()
 
 
 @router.get("/units")
-def list_units():
-    """Return all units."""
+def list_units() -> list[dict]:
+    """Return all units.
+
+    Returns
+    -------
+    list[dict]
+        List of unit objects loaded from :mod:`app.loaders`.
+    """
     loader = get_data_loader()
     return loader.units
 
 
 @router.get("/units/{unit_id}")
-def get_unit(unit_id: str = Path(..., regex="^[a-zA-Z0-9]+$")):
+def get_unit(unit_id: str = Path(..., pattern="^[a-zA-Z0-9]+$")) -> dict:
     """Return unit details by ID.
 
-    The ``unit_id`` path parameter must be alphanumeric. A request with an
-    invalid identifier will return a ``422`` response before reaching this
-    handler.
+    Parameters
+    ----------
+    unit_id:
+        Alphanumeric identifier of the unit.
+
+    Returns
+    -------
+    dict
+        Unit information if found.
+
+    Raises
+    ------
+    HTTPException
+        If no unit with ``unit_id`` exists.
     """
     loader = get_data_loader()
     unit = loader.get_unit_by_id(unit_id)
@@ -28,7 +45,13 @@ def get_unit(unit_id: str = Path(..., regex="^[a-zA-Z0-9]+$")):
 
 
 @router.get("/categories")
-def list_categories():
-    """Return categories data."""
+def list_categories() -> dict:
+    """Return categories data.
+
+    Returns
+    -------
+    dict
+        Mapping of category names to lists of values.
+    """
     loader = get_data_loader()
     return loader.categories

--- a/main.py
+++ b/main.py
@@ -15,7 +15,20 @@ app.include_router(router)
 async def dataloader_error_handler(
     request: Request, exc: DataLoadError
 ) -> JSONResponse:
-    """Return a JSON response when data loading fails."""
+    """Convert :class:`DataLoadError` into a generic ``500`` response.
+
+    Parameters
+    ----------
+    request:
+        Incoming request that triggered the error.
+    exc:
+        The raised :class:`DataLoadError` instance.
+
+    Returns
+    -------
+    JSONResponse
+        Response with a generic error payload.
+    """
     logging.error("Data loading failed: %s", exc)
     return JSONResponse(
         status_code=500,
@@ -24,7 +37,7 @@ async def dataloader_error_handler(
 
 
 @app.on_event("startup")
-def startup_event():
+def startup_event() -> None:
     """Configure logging and load data once on startup."""
     logging.basicConfig(level=logging.INFO)
     from app.loaders import get_data_loader


### PR DESCRIPTION
## Summary
- expand docstrings for DataLoader and all API endpoints
- fix deprecated `regex` argument usage
- document error handler
- add CHANGELOG and reference in README

## Testing
- `flake8`
- `black --check .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a8de70f24832f9aff8464eda84346