### PR TITLE
Enable hyphenated unit IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 - Initial changelog tracking features and dependency updates.
 - .gitignore entries for environment files, compiled Python and test cache.
 
+### Changed
+- Unit ID path parameter now accepts hyphenated IDs.
+
 ### Removed
 - Empty `app/__init__.py` module as namespace packages are supported.
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ https://wcr-api.up.railway.app
 - `GET /units/{id}` – get a unit by ID
 - `GET /categories` – list categories (factions, types, traits, speeds)
 
+Unit IDs consist of lowercase letters, numbers and hyphens.
+
 All endpoints return JSON.
 
 ### Examples
@@ -91,7 +93,7 @@ curl https://wcr-api.up.railway.app/units
 Fetch a single unit:
 
 ```bash
-curl https://wcr-api.up.railway.app/units/abomination
+curl https://wcr-api.up.railway.app/units/ancient-of-war
 ```
 
 Fetch categories:
@@ -111,7 +113,7 @@ base_url = "https://wcr-api.up.railway.app"
 units = requests.get(f"{base_url}/units").json()
 
 # single unit by id
-unit = requests.get(f"{base_url}/units/abomination").json()
+unit = requests.get(f"{base_url}/units/ancient-of-war").json()
 
 # categories
 categories = requests.get(f"{base_url}/categories").json()

--- a/app/api.py
+++ b/app/api.py
@@ -19,13 +19,13 @@ def list_units() -> list[dict]:
 
 
 @router.get("/units/{unit_id}")
-def get_unit(unit_id: str = Path(..., pattern="^[a-zA-Z0-9]+$")) -> dict:
+def get_unit(unit_id: str = Path(..., pattern="^[a-zA-Z0-9-]+$")) -> dict:
     """Return unit details by ID.
 
     Parameters
     ----------
     unit_id:
-        Alphanumeric identifier of the unit.
+        Identifier of the unit. IDs may contain letters, numbers and hyphens.
 
     Returns
     -------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,6 +28,12 @@ def test_get_unit_by_id_or_404():
     assert resp_404.status_code == 404
 
 
+def test_get_unit_with_hyphenated_id():
+    response = client.get("/units/ancient-of-war")
+    assert response.status_code == 200
+    assert response.json()["id"] == "ancient-of-war"
+
+
 def test_categories_structure():
     response = client.get("/categories")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- update path validation in `get_unit` to accept hyphenated IDs
- test retrieving a unit with a hyphenated ID
- mention hyphenated IDs in usage examples
- document change in changelog

## Testing
- `black app tests`
- `flake8`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a92e486b8832f9c7aa69201fab89f