### PR TITLE
Switch to FastAPI lifespan for startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Unit ID path parameter now accepts hyphenated IDs.
+- Startup now uses a FastAPI lifespan function instead of a deprecated
+  ``@app.on_event`` handler.
 
 ### Removed
 - Empty `app/__init__.py` module as namespace packages are supported.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ pip install -r requirements-dev.txt
 uvicorn main:app --reload
 ```
 
-Logging is configured at **INFO** level on startup so you will see data
-loading and request information in the console.
+Logging is configured at **INFO** level by a FastAPI lifespan handler which also
+loads unit data on startup. This ensures the application is ready to serve
+requests immediately and you will see data loading messages in the console.
 
 When running locally the API is available at `http://127.0.0.1:8000`.
 
@@ -56,9 +57,10 @@ pytest cache directories to avoid committing temporary files.
 
 ### Data loading
 
-Unit data is loaded once at startup by `DataLoader` which keeps a dictionary
-for fast lookups. Use `get_unit_by_id` to retrieve a specific unit without
-iterating over the entire list.
+Unit data is loaded once at startup by `DataLoader` via the application's
+lifespan context manager which keeps a dictionary for fast lookups. Use
+`get_unit_by_id` to retrieve a specific unit without iterating over the entire
+list.
 
 If data files cannot be read, the application now returns a 500 JSON response
 with `{"detail": "Internal server error"}` instead of exposing a stack


### PR DESCRIPTION
## Summary
- configure logging and data loading in a FastAPI lifespan handler
- document the new startup behaviour in README and CHANGELOG
- format code and run tests

## Testing
- `black .`
- `flake8`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a975bb6c4832fb16fbe4122eba761