### PR TITLE
Add structured logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 - Expanded docstrings for `DataLoader` and API endpoints.
 - Initial changelog tracking features and dependency updates.
 - .gitignore entries for environment files, compiled Python and test cache.
+- Structured JSON logging with ``structlog`` and request/response middleware.
+- Test coverage for the logging middleware.
 
 ### Changed
 - Unit ID path parameter now accepts hyphenated IDs.

--- a/README.md
+++ b/README.md
@@ -23,9 +23,12 @@ pip install -r requirements-dev.txt
 uvicorn main:app --reload
 ```
 
-Logging is configured at **INFO** level by a FastAPI lifespan handler which also
-loads unit data on startup. This ensures the application is ready to serve
-requests immediately and you will see data loading messages in the console.
+Structured logging is initialised during the application's lifespan using
+``structlog``. Logs are emitted in JSON format at **INFO** level by default and
+include timestamps, log level and request details. The lifespan function also
+loads unit data on startup so the API is ready to serve requests immediately.
+The log level can be customised by calling ``configure_logging`` with a
+different level before starting the app.
 
 When running locally the API is available at `http://127.0.0.1:8000`.
 

--- a/app/logging.py
+++ b/app/logging.py
@@ -1,0 +1,36 @@
+"""Logging utilities for the WCR Data API."""
+
+from __future__ import annotations
+
+import logging
+import structlog
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Configure JSON structured logging for the application.
+
+    Parameters
+    ----------
+    level:
+        Minimum log level to emit. Defaults to :data:`logging.INFO`.
+    """
+
+    logging.basicConfig(format="%(message)s", level=level)
+    structlog.configure(
+        processors=[
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.add_log_level,
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.JSONRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(level),
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
+
+def get_logger() -> structlog.BoundLogger:
+    """Return the module-level structured logger."""
+
+    return structlog.get_logger()

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -1,0 +1,36 @@
+"""ASGI middleware components for the API."""
+
+from __future__ import annotations
+
+import time
+from starlette.middleware.base import BaseHTTPMiddleware
+from .logging import get_logger
+
+logger = get_logger()
+
+
+class LoggingMiddleware(BaseHTTPMiddleware):
+    """Log incoming HTTP requests and responses."""
+
+    async def dispatch(self, request, call_next):
+        start = time.perf_counter()
+        logger.info("request", method=request.method, path=request.url.path)
+        try:
+            response = await call_next(request)
+        except Exception:
+            logger.error(
+                "error",
+                method=request.method,
+                path=request.url.path,
+                exc_info=True,
+            )
+            raise
+        duration = (time.perf_counter() - start) * 1000
+        logger.info(
+            "response",
+            method=request.method,
+            path=request.url.path,
+            status_code=response.status_code,
+            duration_ms=round(duration, 2),
+        )
+        return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.115.13
 uvicorn[standard]==0.34.3
 httpx==0.28.1
+structlog==24.1.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -58,3 +58,20 @@ def test_dataloader_error_returns_500(monkeypatch):
     resp = client.get("/units")
     assert resp.status_code == 500
     assert resp.json() == {"detail": "Internal server error"}
+
+
+def test_logging_middleware_called(caplog):
+    with TestClient(app) as c:
+        c.get("/units")  # ensure startup has run
+        caplog.set_level("INFO")
+        c.get("/units")
+    import json
+
+    events = []
+    for r in caplog.records:
+        try:
+            data = json.loads(r.getMessage())
+            events.append(data.get("event"))
+        except json.JSONDecodeError:
+            continue
+    assert "response" in events


### PR DESCRIPTION
## Summary
- add `structlog` configuration and middleware for JSON logs
- log request/response details and errors
- test that middleware logs a request
- document logging setup

## Testing
- `pre-commit run --files main.py app/logging.py app/middleware.py tests/test_api.py README.md CHANGELOG.md requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a98dcbd2c832f9169e65176bd6174