### PR TITLE
Add pagination to GET /units endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - .gitignore entries for environment files, compiled Python and test cache.
 - Structured JSON logging with ``structlog`` and request/response middleware.
 - Test coverage for the logging middleware.
+- Pagination for ``GET /units`` via ``offset`` and ``limit`` query parameters.
 
 ### Changed
 - Unit ID path parameter now accepts hyphenated IDs.

--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ The API is also deployed and accessible under:
 https://wcr-api.up.railway.app
 ```
 
-### Available Endpoints
+-### Available Endpoints
 
-- `GET /units` – list all units
+- `GET /units` – list units with optional `offset` and `limit` query params
+  (defaults: `offset=0`, `limit=100`, maximum limit `1000`)
 - `GET /units/{id}` – get a unit by ID
 - `GET /categories` – list categories (factions, types, traits, speeds)
 
@@ -89,10 +90,10 @@ All endpoints return JSON.
 
 ### Examples
 
-Fetch all units:
+Fetch a subset of units:
 
 ```bash
-curl https://wcr-api.up.railway.app/units
+curl "https://wcr-api.up.railway.app/units?offset=0&limit=10"
 ```
 
 Fetch a single unit:
@@ -114,8 +115,8 @@ import requests
 
 base_url = "https://wcr-api.up.railway.app"
 
-# list units
-units = requests.get(f"{base_url}/units").json()
+# list units with pagination
+units = requests.get(f"{base_url}/units", params={"offset": 0, "limit": 10}).json()
 
 # single unit by id
 unit = requests.get(f"{base_url}/units/ancient-of-war").json()

--- a/app/api.py
+++ b/app/api.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException, Path
+from fastapi import APIRouter, HTTPException, Path, Query
 
 from .loaders import get_data_loader
 
@@ -6,8 +6,18 @@ router = APIRouter()
 
 
 @router.get("/units")
-def list_units() -> list[dict]:
-    """Return all units.
+def list_units(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=1000),
+) -> list[dict]:
+    """Return a slice of the unit list.
+
+    Parameters
+    ----------
+    offset:
+        Number of items to skip from the start of the list. ``0`` by default.
+    limit:
+        Maximum number of units to return. Values above ``1000`` are rejected.
 
     Returns
     -------
@@ -15,7 +25,8 @@ def list_units() -> list[dict]:
         List of unit objects loaded from :mod:`app.loaders`.
     """
     loader = get_data_loader()
-    return loader.units
+    end = offset + limit
+    return loader.units[offset:end]
 
 
 @router.get("/units/{unit_id}")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 from fastapi.testclient import TestClient
+import pytest
 
 from main import app
 from app.loaders import get_data_loader
@@ -44,6 +45,26 @@ def test_categories_structure():
 
 def test_invalid_unit_id_validation():
     response = client.get("/units/invalid!")
+    assert response.status_code == 422
+
+
+def test_units_pagination():
+    loader = get_data_loader()
+    response = client.get("/units", params={"offset": 1, "limit": 2})
+    assert response.status_code == 200
+    assert response.json() == loader.units[1:3]
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"limit": 0},
+        {"limit": 2000},
+        {"offset": -1},
+    ],
+)
+def test_units_invalid_pagination_params(params):
+    response = client.get("/units", params=params)
     assert response.status_code == 422
 
 


### PR DESCRIPTION
## Summary
- support `offset` and `limit` query params on `/units`
- document new pagination feature and update examples
- test pagination and invalid params
- update changelog

## Testing
- `pre-commit run --files app/api.py tests/test_api.py README.md CHANGELOG.md`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a9e0b5420832f86bb36a920425a0a