### PR TITLE
Handle JSON decode errors and enable coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,8 @@ jobs:
       - name: Lint
         run: pre-commit run --show-diff-on-failure --color=always --all-files
       - name: Test
-        run: python -m pytest -q
+        run: python -m pytest --cov=app --cov=main -q --cov-report=xml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Added
 - Expanded docstrings for `DataLoader` and API endpoints.
+- `DataLoader.load` now reports malformed JSON via `DataLoadError`.
+- Test case for invalid `units.json` to ensure `DataLoadError` is raised.
+- Coverage reporting in CI with `pytest-cov` and uploaded artifact.
 - Initial changelog tracking features and dependency updates.
 - .gitignore entries for environment files, compiled Python and test cache.
 - Structured JSON logging with ``structlog`` and request/response middleware.
@@ -15,6 +18,8 @@ All notable changes to this project will be documented in this file.
 - Unit ID path parameter now accepts hyphenated IDs.
 - Startup now uses a FastAPI lifespan function instead of a deprecated
   ``@app.on_event`` handler.
+- README instructions for running tests with ``python -m pytest`` and corrected
+  the Available Endpoints header.
 
 ### Removed
 - Empty `app/__init__.py` module as namespace packages are supported.

--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ When running locally the API is available at `http://127.0.0.1:8000`.
 
 ### Running Tests
 
-Install development dependencies and run the test suite with `pytest`:
+Install development dependencies and run the test suite with `python -m pytest`.
+Running tests as a module ensures the package imports correctly:
 
 ```bash
 pip install -r requirements-dev.txt
-pytest
+python -m pytest
 ```
 
 ### Code style
@@ -77,7 +78,7 @@ The API is also deployed and accessible under:
 https://wcr-api.up.railway.app
 ```
 
--### Available Endpoints
+### Available Endpoints
 
 - `GET /units` – list units with optional `offset` and `limit` query params
   (defaults: `offset=0`, `limit=100`, maximum limit `1000`)

--- a/app/loaders.py
+++ b/app/loaders.py
@@ -44,7 +44,8 @@ class DataLoader:
         Raises
         ------
         DataLoadError
-            If the files cannot be read or parsed.
+            If the files cannot be read or parsed. Malformed JSON also
+            results in this exception.
         """
         units_file = self.data_dir / "units.json"
         categories_file = self.data_dir / "categories.json"
@@ -53,7 +54,8 @@ class DataLoader:
                 self.units = json.load(f)
             with categories_file.open("r", encoding="utf-8") as f:
                 self.categories = json.load(f)
-        except OSError as exc:  # file read errors
+        except (OSError, json.JSONDecodeError) as exc:
+            # file read errors or invalid JSON
             raise DataLoadError(str(exc)) from exc
 
         self.units_by_id = {unit["id"]: unit for unit in self.units}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 black
 flake8
 pytest
+pytest-cov
 pre-commit

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -25,3 +25,14 @@ def test_load_missing_file(tmp_path):
     loader = DataLoader(tmp_path)
     with pytest.raises(DataLoadError):
         loader.load()
+
+
+def test_load_invalid_json(tmp_path):
+    # create invalid JSON in units.json
+    data_dir = tmp_path
+    (data_dir / "units.json").write_text("{invalid")
+    (data_dir / "categories.json").write_text("[]")
+
+    loader = DataLoader(data_dir)
+    with pytest.raises(DataLoadError):
+        loader.load()


### PR DESCRIPTION
## Summary
- raise DataLoadError for malformed JSON
- test invalid JSON load failure
- document running tests and fix README header
- enable pytest-cov coverage reporting in CI
- list updates in CHANGELOG

## Testing
- `pre-commit run --files .github/workflows/ci.yml CHANGELOG.md README.md app/loaders.py requirements-dev.txt tests/test_loader.py`
- `python -m pytest --cov=app --cov=main -q`

------
https://chatgpt.com/codex/tasks/task_e_685adea65f2c832faf56ce1379c50672